### PR TITLE
Add twice-weekly Supabase keep-alive + user count check

### DIFF
--- a/.github/workflows/supabase-keep-alive.yml
+++ b/.github/workflows/supabase-keep-alive.yml
@@ -6,6 +6,8 @@ on:
     - cron: "0 12 * * 1,4"
   workflow_dispatch: # Allow manual runs from the Actions tab
 
+permissions: {}
+
 jobs:
   ping-and-count-users:
     runs-on: ubuntu-latest

--- a/.github/workflows/supabase-keep-alive.yml
+++ b/.github/workflows/supabase-keep-alive.yml
@@ -36,6 +36,7 @@ jobs:
           # Request 1 user just to get the total count via the X-Total-Count header
           # (GoTrue / Supabase Auth Admin API provides this header)
           HTTP_RESPONSE=$(curl -sS -D /tmp/headers.txt -o /tmp/body.json \
+            --retry 3 --retry-delay 2 --retry-all-errors \
             -w "%{http_code}" \
             "${BASE_URL}/auth/v1/admin/users?page=1&per_page=1" \
             -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \

--- a/.github/workflows/supabase-keep-alive.yml
+++ b/.github/workflows/supabase-keep-alive.yml
@@ -1,0 +1,77 @@
+name: Keep Supabase Alive
+
+on:
+  schedule:
+    # Twice a week ("weekly twice"): Monday and Thursday at 12:00 UTC
+    - cron: "0 12 * * 1,4"
+  workflow_dispatch: # Allow manual runs from the Actions tab
+
+jobs:
+  ping-and-count-users:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Ping Supabase and report current user count
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${SUPABASE_URL:-}" ] || [ -z "${SUPABASE_SERVICE_ROLE_KEY:-}" ]; then
+            echo "❌ Missing required secrets."
+            echo "Please add these repository secrets (Settings → Secrets and variables → Actions):"
+            echo "  • SUPABASE_URL              (e.g. https://xxxx.supabase.co)"
+            echo "  • SUPABASE_SERVICE_ROLE_KEY (from Supabase Dashboard → Project Settings → API)"
+            exit 1
+          fi
+
+          # Normalize URL (remove trailing slash)
+          BASE_URL="${SUPABASE_URL%/}"
+
+          echo "🔄 Pinging Supabase Auth Admin API to keep the project active..."
+          echo "   URL: ${BASE_URL}"
+
+          # Request 1 user just to get the total count via the X-Total-Count header
+          # (GoTrue / Supabase Auth Admin API provides this header)
+          HTTP_RESPONSE=$(curl -sS -D /tmp/headers.txt -o /tmp/body.json \
+            -w "%{http_code}" \
+            "${BASE_URL}/auth/v1/admin/users?page=1&per_page=1" \
+            -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
+            -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
+            -H "Content-Type: application/json")
+
+          if [ "$HTTP_RESPONSE" != "200" ]; then
+            echo "❌ Request failed with HTTP ${HTTP_RESPONSE}"
+            echo "Response body:"
+            cat /tmp/body.json || true
+            exit 1
+          fi
+
+          # Extract total user count from header (preferred) or fall back
+          TOTAL_USERS=$(grep -i '^x-total-count:' /tmp/headers.txt | awk '{print $2}' | tr -d '\r' || true)
+
+          if [ -z "$TOTAL_USERS" ]; then
+            # Fallback: some setups return total inside the JSON body
+            TOTAL_USERS=$(python3 -c "
+import json, sys
+try:
+    data = json.load(open('/tmp/body.json'))
+    if isinstance(data, dict) and 'total' in data:
+        print(data['total'])
+    elif isinstance(data, list):
+        print(len(data))  # incomplete, but better than nothing
+    else:
+        print('unknown')
+except Exception:
+    print('unknown')
+" 2>/dev/null || echo "unknown")
+          fi
+
+          echo ""
+          echo "✅ Supabase is awake!"
+          echo "👥 Current number of users: ${TOTAL_USERS}"
+          echo "🕒 Checked at: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+          echo ""
+          echo "This lightweight ping (twice weekly) prevents the free-tier project from pausing due to inactivity."


### PR DESCRIPTION
## What this does

Adds a lightweight GitHub Action that **pings Supabase twice a week** and reports **how many users currently exist**.

This is a free, zero-cost way to stop the Supabase free-tier project from pausing after inactivity.

### Schedule
- **Monday** and **Thursday** at 12:00 UTC
- Also supports **manual runs** from the Actions tab (`workflow_dispatch`)

### What it queries
Uses the Auth Admin API (`/auth/v1/admin/users`) with the **service role key** to:
1. Keep the project active
2. Read the current total user count (`X-Total-Count` header) and print it in the workflow logs

### Setup required (one-time)
After merging, add these **repository secrets** (Settings → Secrets and variables → Actions):

| Secret name | Where to find it |
|---|---|
| `SUPABASE_URL` | Supabase Dashboard → Project Settings → API → Project URL |
| `SUPABASE_SERVICE_ROLE_KEY` | Same page → `service_role` key (keep this secret!) |

> ⚠️ Never put the service role key in the frontend or commit it. It is only used by this GitHub Action.

### Why this is safe & free
- Runs only twice per week (very low usage)
- No extra paid services
- Uses only GitHub Actions free minutes + your existing Supabase project

---

After merging + adding the secrets, you can test it immediately by going to **Actions → Keep Supabase Alive → Run workflow**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated service health checks that run twice weekly or on demand.
  * Checks validate required configuration and confirm successful authentication service responses.
  * Added retry handling for temporary service issues and clear failure reporting for unsuccessful responses.
  * Monitoring records request status, timestamps, and account totals, helping identify service availability issues early.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->